### PR TITLE
Add numpad mapping for MacOS

### DIFF
--- a/MacOS/README.md
+++ b/MacOS/README.md
@@ -1,1 +1,1 @@
-```sudo cp ./real_prog_dvoark.keylayout /Library/Keyboard\ Layouts```
+```sudo cp ./real_prog_dvorak.keylayout /Library/Keyboard\ Layouts```

--- a/MacOS/README.md
+++ b/MacOS/README.md
@@ -1,1 +1,1 @@
-```sudo cp ./real_prog_dvoark.keylayout /Library/Keybaord\ Layouts```
+```sudo cp ./real_prog_dvoark.keylayout /Library/Keyboard\ Layouts```

--- a/MacOS/real_prog_dvoark.keylayout
+++ b/MacOS/real_prog_dvoark.keylayout
@@ -1,7 +1,7 @@
 <?xml version="1.1" encoding="UTF-8"?>
 <!DOCTYPE keyboard SYSTEM "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
 <!--Created by Ukelele version 343 on 2021-04-05 at 23:37 (BST)-->
-<!--Last edited by Ukelele version 343 on 2021-04-06 at 00:07 (BST)-->
+<!--Last edited by Ukelele version 359 on 2023-08-17 at 00:20 (EDT)-->
 <keyboard group="126" id="-16041" name="real prog dvorak" maxout="1">
     <layouts>
         <layout first="0" last="17" mapSet="ANSI" modifiers="Modifiers"/>
@@ -23,13 +23,7 @@
             <modifier keys="anyShift"/>
         </keyMapSelect>
         <keyMapSelect mapIndex="2">
-            <modifier keys="anyOption"/>
-        </keyMapSelect>
-        <keyMapSelect mapIndex="3">
             <modifier keys="caps"/>
-        </keyMapSelect>
-        <keyMapSelect mapIndex="4">
-            <modifier keys="anyShift caps? anyOption"/>
         </keyMapSelect>
     </modifierMap>
     <keyMapSet id="ANSI">
@@ -44,6 +38,7 @@
             <key code="7" output="q"/>
             <key code="8" output="j"/>
             <key code="9" output="k"/>
+            <key code="10" output=""/>
             <key code="11" output="x"/>
             <key code="12" output=";"/>
             <key code="13" output=","/>
@@ -85,7 +80,7 @@
             <key code="49" output=" "/>
             <key code="50" output="$"/>
             <key code="51" output="&#x0008;"/>
-            <key code="53" action="&#x001B; 1"/>
+            <key code="53" output="&#x001B;"/>
             <key code="64" output="&#x0010;"/>
             <key code="65" output=""/>
             <key code="66" output="&#x001D;"/>
@@ -149,6 +144,7 @@
             <key code="7" output="Q"/>
             <key code="8" output="J"/>
             <key code="9" output="K"/>
+            <key code="10" output=""/>
             <key code="11" output="X"/>
             <key code="12" output=":"/>
             <key code="13" output="&#x003C;"/>
@@ -162,7 +158,7 @@
             <key code="21" output="4"/>
             <key code="22" output="6"/>
             <key code="23" output="5"/>
-            <key code="24" output="."/>
+            <key code="24" output="`"/>
             <key code="25" output="9"/>
             <key code="26" output="7"/>
             <key code="27" output="%"/>
@@ -244,203 +240,57 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="2">
-            <key code="0" output=""/>
-            <key code="1" output=""/>
-            <key code="2" output=""/>
-            <key code="3" output=""/>
-            <key code="4" output=""/>
-            <key code="5" output=""/>
-            <key code="6" output=""/>
-            <key code="7" output=""/>
-            <key code="8" output=""/>
-            <key code="9" output=""/>
-            <key code="11" output=""/>
-            <key code="12" output=""/>
-            <key code="13" output=""/>
-            <key code="14" output=""/>
-            <key code="15" output=""/>
-            <key code="16" output=""/>
-            <key code="17" output=""/>
-            <key code="18" output=""/>
-            <key code="19" output=""/>
-            <key code="20" output=""/>
-            <key code="21" output=""/>
-            <key code="22" output=""/>
-            <key code="23" output=""/>
-            <key code="24" output=""/>
-            <key code="25" output=""/>
-            <key code="26" output=""/>
-            <key code="27" output=""/>
-            <key code="28" output=""/>
-            <key code="29" output=""/>
-            <key code="30" output=""/>
-            <key code="31" output=""/>
-            <key code="32" output=""/>
-            <key code="33" output=""/>
-            <key code="34" output=""/>
-            <key code="35" output=""/>
+            <key code="0" output="A"/>
+            <key code="1" output="O"/>
+            <key code="2" output="E"/>
+            <key code="3" output="U"/>
+            <key code="4" output="D"/>
+            <key code="5" output="I"/>
+            <key code="6" output="&#x0027;"/>
+            <key code="7" output="Q"/>
+            <key code="8" output="J"/>
+            <key code="9" output="K"/>
+            <key code="10" output=""/>
+            <key code="11" output="X"/>
+            <key code="12" output=";"/>
+            <key code="13" output=","/>
+            <key code="14" output="."/>
+            <key code="15" output="P"/>
+            <key code="16" output="F"/>
+            <key code="17" output="Y"/>
+            <key code="18" output="1"/>
+            <key code="19" output="2"/>
+            <key code="20" output="3"/>
+            <key code="21" output="4"/>
+            <key code="22" output="6"/>
+            <key code="23" output="5"/>
+            <key code="24" output="|"/>
+            <key code="25" output="9"/>
+            <key code="26" output="7"/>
+            <key code="27" output="!"/>
+            <key code="28" output="8"/>
+            <key code="29" output="0"/>
+            <key code="30" output="@"/>
+            <key code="31" output="R"/>
+            <key code="32" output="G"/>
+            <key code="33" output="/"/>
+            <key code="34" output="C"/>
+            <key code="35" output="L"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output=""/>
-            <key code="38" output=""/>
-            <key code="39" output=""/>
-            <key code="40" output=""/>
-            <key code="41" output=""/>
-            <key code="42" output=""/>
-            <key code="43" output=""/>
-            <key code="44" output=""/>
-            <key code="45" output=""/>
-            <key code="46" output=""/>
-            <key code="47" output=""/>
+            <key code="37" output="N"/>
+            <key code="38" output="H"/>
+            <key code="39" output="_"/>
+            <key code="40" output="T"/>
+            <key code="41" output="S"/>
+            <key code="42" output="\"/>
+            <key code="43" output="W"/>
+            <key code="44" output="Z"/>
+            <key code="45" output="B"/>
+            <key code="46" output="M"/>
+            <key code="47" output="V"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output=""/>
-            <key code="50" output=""/>
-            <key code="51" output="&#x0008;"/>
-            <key code="53" output="&#x001B;"/>
-            <key code="64" output="&#x0010;"/>
-            <key code="65" output=""/>
-            <key code="66" output="&#x001D;"/>
-            <key code="67" output=""/>
-            <key code="69" output=""/>
-            <key code="70" output="&#x001C;"/>
-            <key code="71" output="&#x001B;"/>
-            <key code="72" output="&#x001F;"/>
-            <key code="75" output=""/>
-            <key code="76" output="&#x0003;"/>
-            <key code="77" output="&#x001E;"/>
-            <key code="78" output=""/>
-            <key code="79" output="&#x0010;"/>
-            <key code="80" output="&#x0010;"/>
-            <key code="81" output=""/>
-            <key code="82" output=""/>
-            <key code="83" output=""/>
-            <key code="84" output=""/>
-            <key code="85" output=""/>
-            <key code="86" output=""/>
-            <key code="87" output=""/>
-            <key code="88" output=""/>
-            <key code="89" output=""/>
-            <key code="91" output=""/>
-            <key code="92" output=""/>
-            <key code="96" output="&#x0010;"/>
-            <key code="97" output="&#x0010;"/>
-            <key code="98" output="&#x0010;"/>
-            <key code="99" output="&#x0010;"/>
-            <key code="100" output="&#x0010;"/>
-            <key code="101" output="&#x0010;"/>
-            <key code="103" output="&#x0010;"/>
-            <key code="105" output="&#x0010;"/>
-            <key code="106" output="&#x0010;"/>
-            <key code="107" output="&#x0010;"/>
-            <key code="109" output="&#x0010;"/>
-            <key code="111" output="&#x0010;"/>
-            <key code="113" output="&#x0010;"/>
-            <key code="114" output="&#x0005;"/>
-            <key code="115" output="&#x0001;"/>
-            <key code="116" output="&#x000B;"/>
-            <key code="117" output="&#x007F;"/>
-            <key code="118" output="&#x0010;"/>
-            <key code="119" output="&#x0004;"/>
-            <key code="120" output="&#x0010;"/>
-            <key code="121" output="&#x000C;"/>
-            <key code="122" output="&#x0010;"/>
-            <key code="123" output="&#x001C;"/>
-            <key code="124" output="&#x001D;"/>
-            <key code="125" output="&#x001F;"/>
-            <key code="126" output="&#x001E;"/>
-        </keyMap>
-        <keyMap index="3">
-            <key code="0" output=""/>
-            <key code="36" output="&#x000D;"/>
-            <key code="48" output="&#x0009;"/>
-            <key code="51" output="&#x0008;"/>
-            <key code="53" output="&#x001B;"/>
-            <key code="64" output="&#x0010;"/>
-            <key code="66" output="&#x001D;"/>
-            <key code="70" output="&#x001C;"/>
-            <key code="71" output="&#x001B;"/>
-            <key code="72" output="&#x001F;"/>
-            <key code="76" output="&#x0003;"/>
-            <key code="77" output="&#x001E;"/>
-            <key code="79" output="&#x0010;"/>
-            <key code="80" output="&#x0010;"/>
-            <key code="96" output="&#x0010;"/>
-            <key code="97" output="&#x0010;"/>
-            <key code="98" output="&#x0010;"/>
-            <key code="99" output="&#x0010;"/>
-            <key code="100" output="&#x0010;"/>
-            <key code="101" output="&#x0010;"/>
-            <key code="103" output="&#x0010;"/>
-            <key code="105" output="&#x0010;"/>
-            <key code="106" output="&#x0010;"/>
-            <key code="107" output="&#x0010;"/>
-            <key code="109" output="&#x0010;"/>
-            <key code="111" output="&#x0010;"/>
-            <key code="113" output="&#x0010;"/>
-            <key code="114" output="&#x0005;"/>
-            <key code="115" output="&#x0001;"/>
-            <key code="116" output="&#x000B;"/>
-            <key code="117" output="&#x007F;"/>
-            <key code="118" output="&#x0010;"/>
-            <key code="119" output="&#x0004;"/>
-            <key code="120" output="&#x0010;"/>
-            <key code="121" output="&#x000C;"/>
-            <key code="122" output="&#x0010;"/>
-            <key code="123" output="&#x001C;"/>
-            <key code="124" output="&#x001D;"/>
-            <key code="125" output="&#x001F;"/>
-            <key code="126" output="&#x001E;"/>
-        </keyMap>
-        <keyMap index="4">
-            <key code="0" output=""/>
-            <key code="1" output=""/>
-            <key code="2" output=""/>
-            <key code="3" output=""/>
-            <key code="4" output=""/>
-            <key code="5" output=""/>
-            <key code="6" output=""/>
-            <key code="7" output=""/>
-            <key code="8" output=""/>
-            <key code="9" output=""/>
-            <key code="11" output=""/>
-            <key code="12" output=""/>
-            <key code="13" output=""/>
-            <key code="14" output=""/>
-            <key code="15" output=""/>
-            <key code="16" output=""/>
-            <key code="17" output=""/>
-            <key code="18" output=""/>
-            <key code="19" output=""/>
-            <key code="20" output=""/>
-            <key code="21" output=""/>
-            <key code="22" output=""/>
-            <key code="23" output=""/>
-            <key code="24" output=""/>
-            <key code="25" output=""/>
-            <key code="26" output=""/>
-            <key code="27" output=""/>
-            <key code="28" output=""/>
-            <key code="29" output=""/>
-            <key code="30" output=""/>
-            <key code="31" output=""/>
-            <key code="32" output=""/>
-            <key code="33" output=""/>
-            <key code="34" output=""/>
-            <key code="35" output=""/>
-            <key code="36" output="&#x000D;"/>
-            <key code="37" output=""/>
-            <key code="38" output=""/>
-            <key code="39" output=""/>
-            <key code="40" output=""/>
-            <key code="41" output=""/>
-            <key code="42" output=""/>
-            <key code="43" output=""/>
-            <key code="44" output=""/>
-            <key code="45" output=""/>
-            <key code="46" output=""/>
-            <key code="47" output=""/>
-            <key code="48" output="&#x0009;"/>
-            <key code="49" output=""/>
-            <key code="50" output=""/>
+            <key code="50" output="$"/>
             <key code="51" output="&#x0008;"/>
             <key code="53" output="&#x001B;"/>
             <key code="64" output="&#x0010;"/>
@@ -504,12 +354,6 @@
             <key code="512" output=""/>
         </keyMap>
         <keyMap index="2" baseMapSet="ANSI" baseIndex="2">
-            <key code="512" output=""/>
-        </keyMap>
-        <keyMap index="3" baseMapSet="ANSI" baseIndex="3">
-            <key code="512" output=""/>
-        </keyMap>
-        <keyMap index="4" baseMapSet="ANSI" baseIndex="4">
             <key code="512" output=""/>
         </keyMap>
     </keyMapSet>

--- a/MacOS/real_prog_dvorak.keylayout
+++ b/MacOS/real_prog_dvorak.keylayout
@@ -1,7 +1,7 @@
 <?xml version="1.1" encoding="UTF-8"?>
 <!DOCTYPE keyboard SYSTEM "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
 <!--Created by Ukelele version 343 on 2021-04-05 at 23:37 (BST)-->
-<!--Last edited by Ukelele version 359 on 2023-08-17 at 00:20 (EDT)-->
+<!--Last edited by Ukelele version 359 on 2023-08-19 at 19:04 (CDT)-->
 <keyboard group="126" id="-16041" name="real prog dvorak" maxout="1">
     <layouts>
         <layout first="0" last="17" mapSet="ANSI" modifiers="Modifiers"/>
@@ -82,30 +82,30 @@
             <key code="51" output="&#x0008;"/>
             <key code="53" output="&#x001B;"/>
             <key code="64" output="&#x0010;"/>
-            <key code="65" output=""/>
+            <key code="65" output="."/>
             <key code="66" output="&#x001D;"/>
-            <key code="67" output=""/>
-            <key code="69" output=""/>
+            <key code="67" output="*"/>
+            <key code="69" output="+"/>
             <key code="70" output="&#x001C;"/>
             <key code="71" output="&#x001B;"/>
             <key code="72" output="&#x001F;"/>
-            <key code="75" output=""/>
+            <key code="75" output="/"/>
             <key code="76" output="&#x0003;"/>
             <key code="77" output="&#x001E;"/>
-            <key code="78" output=""/>
+            <key code="78" output="-"/>
             <key code="79" output="&#x0010;"/>
             <key code="80" output="&#x0010;"/>
-            <key code="81" output=""/>
-            <key code="82" output=""/>
-            <key code="83" output=""/>
-            <key code="84" output=""/>
-            <key code="85" output=""/>
-            <key code="86" output=""/>
-            <key code="87" output=""/>
-            <key code="88" output=""/>
-            <key code="89" output=""/>
-            <key code="91" output=""/>
-            <key code="92" output=""/>
+            <key code="81" output="="/>
+            <key code="82" output="0"/>
+            <key code="83" output="1"/>
+            <key code="84" output="2"/>
+            <key code="85" output="3"/>
+            <key code="86" output="4"/>
+            <key code="87" output="5"/>
+            <key code="88" output="6"/>
+            <key code="89" output="7"/>
+            <key code="91" output="8"/>
+            <key code="92" output="9"/>
             <key code="96" output="&#x0010;"/>
             <key code="97" output="&#x0010;"/>
             <key code="98" output="&#x0010;"/>

--- a/MacOS/real_prog_dvorak.keylayout
+++ b/MacOS/real_prog_dvorak.keylayout
@@ -1,7 +1,7 @@
 <?xml version="1.1" encoding="UTF-8"?>
 <!DOCTYPE keyboard SYSTEM "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
 <!--Created by Ukelele version 343 on 2021-04-05 at 23:37 (BST)-->
-<!--Last edited by Ukelele version 359 on 2023-08-19 at 19:04 (CDT)-->
+<!--Last edited by Ukelele version 359 on 2024-05-30 at 14:47 (CDT)-->
 <keyboard group="126" id="-16041" name="real prog dvorak" maxout="1">
     <layouts>
         <layout first="0" last="17" mapSet="ANSI" modifiers="Modifiers"/>
@@ -188,30 +188,30 @@
             <key code="51" output="&#x0008;"/>
             <key code="53" output="&#x001B;"/>
             <key code="64" output="&#x0010;"/>
-            <key code="65" output=""/>
+            <key code="65" output="."/>
             <key code="66" output="&#x001D;"/>
-            <key code="67" output=""/>
-            <key code="69" output=""/>
+            <key code="67" output="*"/>
+            <key code="69" output="+"/>
             <key code="70" output="&#x001C;"/>
             <key code="71" output="&#x001B;"/>
             <key code="72" output="&#x001F;"/>
-            <key code="75" output=""/>
+            <key code="75" output="/"/>
             <key code="76" output="&#x0003;"/>
             <key code="77" output="&#x001E;"/>
-            <key code="78" output=""/>
+            <key code="78" output="-"/>
             <key code="79" output="&#x0010;"/>
             <key code="80" output="&#x0010;"/>
-            <key code="81" output=""/>
-            <key code="82" output=""/>
-            <key code="83" output=""/>
-            <key code="84" output=""/>
-            <key code="85" output=""/>
-            <key code="86" output=""/>
-            <key code="87" output=""/>
-            <key code="88" output=""/>
-            <key code="89" output=""/>
-            <key code="91" output=""/>
-            <key code="92" output=""/>
+            <key code="81" output="="/>
+            <key code="82" output="0"/>
+            <key code="83" output="1"/>
+            <key code="84" output="2"/>
+            <key code="85" output="3"/>
+            <key code="86" output="4"/>
+            <key code="87" output="5"/>
+            <key code="88" output="6"/>
+            <key code="89" output="7"/>
+            <key code="91" output="8"/>
+            <key code="92" output="9"/>
             <key code="96" output="&#x0010;"/>
             <key code="97" output="&#x0010;"/>
             <key code="98" output="&#x0010;"/>
@@ -294,30 +294,30 @@
             <key code="51" output="&#x0008;"/>
             <key code="53" output="&#x001B;"/>
             <key code="64" output="&#x0010;"/>
-            <key code="65" output=""/>
+            <key code="65" output="."/>
             <key code="66" output="&#x001D;"/>
-            <key code="67" output=""/>
-            <key code="69" output=""/>
+            <key code="67" output="*"/>
+            <key code="69" output="+"/>
             <key code="70" output="&#x001C;"/>
             <key code="71" output="&#x001B;"/>
             <key code="72" output="&#x001F;"/>
-            <key code="75" output=""/>
+            <key code="75" output="/"/>
             <key code="76" output="&#x0003;"/>
             <key code="77" output="&#x001E;"/>
-            <key code="78" output=""/>
+            <key code="78" output="-"/>
             <key code="79" output="&#x0010;"/>
             <key code="80" output="&#x0010;"/>
-            <key code="81" output=""/>
-            <key code="82" output=""/>
-            <key code="83" output=""/>
-            <key code="84" output=""/>
-            <key code="85" output=""/>
-            <key code="86" output=""/>
-            <key code="87" output=""/>
-            <key code="88" output=""/>
-            <key code="89" output=""/>
-            <key code="91" output=""/>
-            <key code="92" output=""/>
+            <key code="81" output="="/>
+            <key code="82" output="0"/>
+            <key code="83" output="1"/>
+            <key code="84" output="2"/>
+            <key code="85" output="3"/>
+            <key code="86" output="4"/>
+            <key code="87" output="5"/>
+            <key code="88" output="6"/>
+            <key code="89" output="7"/>
+            <key code="91" output="8"/>
+            <key code="92" output="9"/>
             <key code="96" output="&#x0010;"/>
             <key code="97" output="&#x0010;"/>
             <key code="98" output="&#x0010;"/>


### PR DESCRIPTION
Builds on #15

- Add mapping for the numpad on MacOS
- Fix spelling in the `real_prog_dvorak.keylayout` filename