### PR TITLE
fix: esc in Zed editor and backtick

### DIFF
--- a/MacOS/real_prog_dvoark.keylayout
+++ b/MacOS/real_prog_dvoark.keylayout
@@ -1,8 +1,8 @@
 <?xml version="1.1" encoding="UTF-8"?>
 <!DOCTYPE keyboard SYSTEM "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
 <!--Created by Ukelele version 343 on 2021-04-05 at 23:37 (BST)-->
-<!--Last edited by Ukelele version 452 on 2025-11-04 at 15:29 (PST)-->
-<keyboard group="126" id="-16041" name="real prog dvorak" maxout="1">
+<!--Last edited by Ukelele version 452 on 2025-12-25 at 10:24 (PST)-->
+<keyboard group="126" id="-17322" name="real prog dvorak" maxout="1">
     <layouts>
         <layout first="0" last="17" mapSet="ANSI" modifiers="Modifiers"/>
         <layout first="18" last="18" mapSet="JIS" modifiers="Modifiers"/>
@@ -20,16 +20,10 @@
             <modifier keys=""/>
         </keyMapSelect>
         <keyMapSelect mapIndex="1">
-            <modifier keys="anyShift"/>
+            <modifier keys="anyShift anyOption? command? anyControl?"/>
         </keyMapSelect>
         <keyMapSelect mapIndex="2">
-            <modifier keys="anyOption"/>
-        </keyMapSelect>
-        <keyMapSelect mapIndex="3">
-            <modifier keys="caps"/>
-        </keyMapSelect>
-        <keyMapSelect mapIndex="4">
-            <modifier keys="anyShift caps? anyOption"/>
+            <modifier keys="caps anyOption? command? anyControl?"/>
         </keyMapSelect>
     </modifierMap>
     <keyMapSet id="ANSI">
@@ -246,203 +240,57 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="2">
-            <key code="0" output=""/>
-            <key code="1" output=""/>
-            <key code="2" output=""/>
-            <key code="3" output=""/>
-            <key code="4" output=""/>
-            <key code="5" output=""/>
-            <key code="6" output=""/>
-            <key code="7" output=""/>
-            <key code="8" output=""/>
-            <key code="9" output=""/>
-            <key code="11" output=""/>
-            <key code="12" output=""/>
-            <key code="13" output=""/>
-            <key code="14" output=""/>
-            <key code="15" output=""/>
-            <key code="16" output=""/>
-            <key code="17" output=""/>
-            <key code="18" output=""/>
-            <key code="19" output=""/>
-            <key code="20" output=""/>
-            <key code="21" output=""/>
-            <key code="22" output=""/>
-            <key code="23" output=""/>
-            <key code="24" output=""/>
-            <key code="25" output=""/>
-            <key code="26" output=""/>
-            <key code="27" output=""/>
-            <key code="28" output=""/>
-            <key code="29" output=""/>
-            <key code="30" output=""/>
-            <key code="31" output=""/>
-            <key code="32" output=""/>
-            <key code="33" output=""/>
-            <key code="34" output=""/>
-            <key code="35" output=""/>
+            <key code="0" output="A"/>
+            <key code="1" output="O"/>
+            <key code="2" output="E"/>
+            <key code="3" output="U"/>
+            <key code="4" output="D"/>
+            <key code="5" output="I"/>
+            <key code="6" output="&#x0022;"/>
+            <key code="7" output="Q"/>
+            <key code="8" output="J"/>
+            <key code="9" output="K"/>
+            <key code="10" output=""/>
+            <key code="11" output="X"/>
+            <key code="12" output=":"/>
+            <key code="13" output="&#x003C;"/>
+            <key code="14" output="&#x003E;"/>
+            <key code="15" output="P"/>
+            <key code="16" output="F"/>
+            <key code="17" output="Y"/>
+            <key code="18" output="1"/>
+            <key code="19" output="2"/>
+            <key code="20" output="3"/>
+            <key code="21" output="4"/>
+            <key code="22" output="6"/>
+            <key code="23" output="5"/>
+            <key code="24" output="`"/>
+            <key code="25" output="9"/>
+            <key code="26" output="7"/>
+            <key code="27" output="%"/>
+            <key code="28" output="8"/>
+            <key code="29" output="0"/>
+            <key code="30" output="^"/>
+            <key code="31" output="R"/>
+            <key code="32" output="G"/>
+            <key code="33" output="?"/>
+            <key code="34" output="C"/>
+            <key code="35" output="L"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" output=""/>
-            <key code="38" output=""/>
-            <key code="39" output=""/>
-            <key code="40" output=""/>
-            <key code="41" output=""/>
-            <key code="42" output=""/>
-            <key code="43" output=""/>
-            <key code="44" output=""/>
-            <key code="45" output=""/>
-            <key code="46" output=""/>
-            <key code="47" output=""/>
+            <key code="37" output="N"/>
+            <key code="38" output="H"/>
+            <key code="39" output="_"/>
+            <key code="40" output="T"/>
+            <key code="41" output="S"/>
+            <key code="42" output="#"/>
+            <key code="43" output="W"/>
+            <key code="44" output="Z"/>
+            <key code="45" output="B"/>
+            <key code="46" output="M"/>
+            <key code="47" output="V"/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" output=""/>
-            <key code="50" output=""/>
-            <key code="51" output="&#x0008;"/>
-            <key code="53" output="&#x001B;"/>
-            <key code="64" output="&#x0010;"/>
-            <key code="65" output=""/>
-            <key code="66" output="&#x001D;"/>
-            <key code="67" output=""/>
-            <key code="69" output=""/>
-            <key code="70" output="&#x001C;"/>
-            <key code="71" output="&#x001B;"/>
-            <key code="72" output="&#x001F;"/>
-            <key code="75" output=""/>
-            <key code="76" output="&#x0003;"/>
-            <key code="77" output="&#x001E;"/>
-            <key code="78" output=""/>
-            <key code="79" output="&#x0010;"/>
-            <key code="80" output="&#x0010;"/>
-            <key code="81" output=""/>
-            <key code="82" output=""/>
-            <key code="83" output=""/>
-            <key code="84" output=""/>
-            <key code="85" output=""/>
-            <key code="86" output=""/>
-            <key code="87" output=""/>
-            <key code="88" output=""/>
-            <key code="89" output=""/>
-            <key code="91" output=""/>
-            <key code="92" output=""/>
-            <key code="96" output="&#x0010;"/>
-            <key code="97" output="&#x0010;"/>
-            <key code="98" output="&#x0010;"/>
-            <key code="99" output="&#x0010;"/>
-            <key code="100" output="&#x0010;"/>
-            <key code="101" output="&#x0010;"/>
-            <key code="103" output="&#x0010;"/>
-            <key code="105" output="&#x0010;"/>
-            <key code="106" output="&#x0010;"/>
-            <key code="107" output="&#x0010;"/>
-            <key code="109" output="&#x0010;"/>
-            <key code="111" output="&#x0010;"/>
-            <key code="113" output="&#x0010;"/>
-            <key code="114" output="&#x0005;"/>
-            <key code="115" output="&#x0001;"/>
-            <key code="116" output="&#x000B;"/>
-            <key code="117" output="&#x007F;"/>
-            <key code="118" output="&#x0010;"/>
-            <key code="119" output="&#x0004;"/>
-            <key code="120" output="&#x0010;"/>
-            <key code="121" output="&#x000C;"/>
-            <key code="122" output="&#x0010;"/>
-            <key code="123" output="&#x001C;"/>
-            <key code="124" output="&#x001D;"/>
-            <key code="125" output="&#x001F;"/>
-            <key code="126" output="&#x001E;"/>
-        </keyMap>
-        <keyMap index="3">
-            <key code="0" output=""/>
-            <key code="36" output="&#x000D;"/>
-            <key code="48" output="&#x0009;"/>
-            <key code="51" output="&#x0008;"/>
-            <key code="53" output="&#x001B;"/>
-            <key code="64" output="&#x0010;"/>
-            <key code="66" output="&#x001D;"/>
-            <key code="70" output="&#x001C;"/>
-            <key code="71" output="&#x001B;"/>
-            <key code="72" output="&#x001F;"/>
-            <key code="76" output="&#x0003;"/>
-            <key code="77" output="&#x001E;"/>
-            <key code="79" output="&#x0010;"/>
-            <key code="80" output="&#x0010;"/>
-            <key code="96" output="&#x0010;"/>
-            <key code="97" output="&#x0010;"/>
-            <key code="98" output="&#x0010;"/>
-            <key code="99" output="&#x0010;"/>
-            <key code="100" output="&#x0010;"/>
-            <key code="101" output="&#x0010;"/>
-            <key code="103" output="&#x0010;"/>
-            <key code="105" output="&#x0010;"/>
-            <key code="106" output="&#x0010;"/>
-            <key code="107" output="&#x0010;"/>
-            <key code="109" output="&#x0010;"/>
-            <key code="111" output="&#x0010;"/>
-            <key code="113" output="&#x0010;"/>
-            <key code="114" output="&#x0005;"/>
-            <key code="115" output="&#x0001;"/>
-            <key code="116" output="&#x000B;"/>
-            <key code="117" output="&#x007F;"/>
-            <key code="118" output="&#x0010;"/>
-            <key code="119" output="&#x0004;"/>
-            <key code="120" output="&#x0010;"/>
-            <key code="121" output="&#x000C;"/>
-            <key code="122" output="&#x0010;"/>
-            <key code="123" output="&#x001C;"/>
-            <key code="124" output="&#x001D;"/>
-            <key code="125" output="&#x001F;"/>
-            <key code="126" output="&#x001E;"/>
-        </keyMap>
-        <keyMap index="4">
-            <key code="0" output=""/>
-            <key code="1" output=""/>
-            <key code="2" output=""/>
-            <key code="3" output=""/>
-            <key code="4" output=""/>
-            <key code="5" output=""/>
-            <key code="6" output=""/>
-            <key code="7" output=""/>
-            <key code="8" output=""/>
-            <key code="9" output=""/>
-            <key code="11" output=""/>
-            <key code="12" output=""/>
-            <key code="13" output=""/>
-            <key code="14" output=""/>
-            <key code="15" output=""/>
-            <key code="16" output=""/>
-            <key code="17" output=""/>
-            <key code="18" output=""/>
-            <key code="19" output=""/>
-            <key code="20" output=""/>
-            <key code="21" output=""/>
-            <key code="22" output=""/>
-            <key code="23" output=""/>
-            <key code="24" output=""/>
-            <key code="25" output=""/>
-            <key code="26" output=""/>
-            <key code="27" output=""/>
-            <key code="28" output=""/>
-            <key code="29" output=""/>
-            <key code="30" output=""/>
-            <key code="31" output=""/>
-            <key code="32" output=""/>
-            <key code="33" output=""/>
-            <key code="34" output=""/>
-            <key code="35" output=""/>
-            <key code="36" output="&#x000D;"/>
-            <key code="37" output=""/>
-            <key code="38" output=""/>
-            <key code="39" output=""/>
-            <key code="40" output=""/>
-            <key code="41" output=""/>
-            <key code="42" output=""/>
-            <key code="43" output=""/>
-            <key code="44" output=""/>
-            <key code="45" output=""/>
-            <key code="46" output=""/>
-            <key code="47" output=""/>
-            <key code="48" output="&#x0009;"/>
-            <key code="49" output=""/>
-            <key code="50" output=""/>
+            <key code="49" output=" "/>
+            <key code="50" output="~"/>
             <key code="51" output="&#x0008;"/>
             <key code="53" output="&#x001B;"/>
             <key code="64" output="&#x0010;"/>
@@ -506,12 +354,6 @@
             <key code="512" output=""/>
         </keyMap>
         <keyMap index="2" baseMapSet="ANSI" baseIndex="2">
-            <key code="512" output=""/>
-        </keyMap>
-        <keyMap index="3" baseMapSet="ANSI" baseIndex="3">
-            <key code="512" output=""/>
-        </keyMap>
-        <keyMap index="4" baseMapSet="ANSI" baseIndex="4">
             <key code="512" output=""/>
         </keyMap>
     </keyMapSet>

--- a/MacOS/real_prog_dvoark.keylayout
+++ b/MacOS/real_prog_dvoark.keylayout
@@ -1,7 +1,7 @@
 <?xml version="1.1" encoding="UTF-8"?>
 <!DOCTYPE keyboard SYSTEM "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
 <!--Created by Ukelele version 343 on 2021-04-05 at 23:37 (BST)-->
-<!--Last edited by Ukelele version 343 on 2021-04-06 at 00:07 (BST)-->
+<!--Last edited by Ukelele version 452 on 2025-11-04 at 15:29 (PST)-->
 <keyboard group="126" id="-16041" name="real prog dvorak" maxout="1">
     <layouts>
         <layout first="0" last="17" mapSet="ANSI" modifiers="Modifiers"/>
@@ -44,6 +44,7 @@
             <key code="7" output="q"/>
             <key code="8" output="j"/>
             <key code="9" output="k"/>
+            <key code="10" output=""/>
             <key code="11" output="x"/>
             <key code="12" output=";"/>
             <key code="13" output=","/>
@@ -85,7 +86,7 @@
             <key code="49" output=" "/>
             <key code="50" output="$"/>
             <key code="51" output="&#x0008;"/>
-            <key code="53" action="&#x001B; 1"/>
+            <key code="53" output="&#x001B;"/>
             <key code="64" output="&#x0010;"/>
             <key code="65" output=""/>
             <key code="66" output="&#x001D;"/>
@@ -149,6 +150,7 @@
             <key code="7" output="Q"/>
             <key code="8" output="J"/>
             <key code="9" output="K"/>
+            <key code="10" output=""/>
             <key code="11" output="X"/>
             <key code="12" output=":"/>
             <key code="13" output="&#x003C;"/>
@@ -162,7 +164,7 @@
             <key code="21" output="4"/>
             <key code="22" output="6"/>
             <key code="23" output="5"/>
-            <key code="24" output="."/>
+            <key code="24" output="`"/>
             <key code="25" output="9"/>
             <key code="26" output="7"/>
             <key code="27" output="%"/>
@@ -513,15 +515,4 @@
             <key code="512" output=""/>
         </keyMap>
     </keyMapSet>
-    <actions>
-        <action id="&#x001B;">
-            <when state="none" next="Dead Key State 0"/>
-        </action>
-        <action id="&#x001B; 1">
-            <when state="none" next="Dead Key State 0"/>
-        </action>
-    </actions>
-    <terminators>
-        <when state="Dead Key State 0" output=""/>
-    </terminators>
 </keyboard>


### PR DESCRIPTION
VIM mode in Zed was not responding to the ESC key without this change.

The keyboard layout had period in two places, fixed one to be backtick (which was missing).